### PR TITLE
FB updated URL to .workplace.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "author": "Rico Herwig <rherwig4711@gmail.com>",
     "license": "MIT",
     "config": {
-        "serviceURL": "https://{teamId}.facebook.com/chat",
+        "serviceURL": "https://{teamId}.workplace.com/chat",
         "hasNotificationSound": true,
         "hasDirectMessages": true,
         "hasTeamId": true,
-        "urlInputSuffix": ".facebook.com"
+        "urlInputSuffix": ".workplace.com"
     }
   }


### PR DESCRIPTION
Workplace has now started using .workplace.com from .facebook.com. Currently, URLs on the browser are redirected, but looks like Franz doesn't support redirection. Workplace right now shows an empty page for Franz. 